### PR TITLE
stage 7: APU implementation

### DIFF
--- a/include/apu.h
+++ b/include/apu.h
@@ -1,0 +1,219 @@
+#ifndef APU_HEADER
+#define APU_HEADER
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* APU registers (to interact with the MMU) */
+// global control registers
+#define NR50 0xFF24  // sound volume control (and VIN panning, unused)
+#define NR51 0xFF25  // sound panning (left/center/right)
+#define NR52 0xFF26  // sound on/off
+
+// CH1
+// - square wave pulse (with sweep)
+// - duty cycle
+// - envelope volume (automatic)
+#define NR10 0xFF10  // sweep register
+#define NR11 0xFF11  // sound length and duty cycle
+#define NR12 0xFF12  // envelope register
+#define NR13 0xFF13  // frequency low byte
+#define NR14 0xFF14  // frequency high byte and control
+
+// CH2
+// - square wave pulse (no sweep)
+// - duty cycle
+// - envelope volume (automatic)
+#define NR21 0xFF16  // sound length and duty cycle
+#define NR22 0xFF17  // envelope register
+#define NR23 0xFF18  // frequency low byte
+#define NR24 0xFF19  // frequency high byte and control
+
+// CH3
+// - wave channel (user-supplied wave pattern)
+// - 4-bit
+// - no envelope
+#define NR30 0xFF1A  // sound on/off
+#define NR31 0xFF1B  // sound length
+#define NR32 0xFF1C  // output level (2-bit)
+#define NR33 0xFF1D  // frequency low byte
+#define NR34 0xFF1E  // frequency high byte and control
+
+// CH4
+// - noise channel (randomly switched frequency)
+#define NR41 0xFF20  // sound length
+#define NR42 0xFF21  // envelope register
+#define NR43 0xFF22  // frequency control
+#define NR44 0xFF23  // control register
+
+struct CPU;
+struct MMU;
+
+/* channel 1 type */
+typedef struct {
+    // sweep
+    uint8_t sweep_period;        // sweep period (0-7)
+    uint8_t sweep_shift;         // sweep shift (0-7)
+    bool sweep_negate;           // sweep negate (true/false)
+    bool sweep_enabled;          // sweep enabled (true/false)
+    int sweep_timer;             // sweep timer (in CPU cycles)
+    int sweep_shadow_frequency;  // shadow frequency (for sweep calculations)
+
+    // duty and length
+    uint8_t duty;            // duty cycle (0-3)
+    uint8_t length_counter;  // length counter (0-63)
+    bool length_enabled;     // length enabled (true/false)
+
+    // envelope
+    uint8_t envelope_volume;        // envelope volume (0-15)
+    uint8_t enevelope_init_volume;  // initial envelope volume (0-15)
+    uint8_t envelope_period;        // envelope period (0-7)
+    bool
+        envelope_direction;  //  direction (true -> increase, false -> decrease)
+    int envelope_timer;      // envelope timer (in CPU cycles)
+
+    // frequency
+    uint16_t frequency;   // frequency (0-2047)
+    int frequency_timer;  // frequency timer (in CPU cycles)
+
+    // control and output
+    bool enabled;          // channel enabled (true/false)
+    bool dac_enabled;      // DAC enabled (true/false)
+    uint8_t output_level;  // output level (0-3)
+    int duty_position;     // current duty position (0-7)
+} ch1_t;
+
+/* channel 2 type (same as ch1 but no sweep) */
+typedef struct {
+    // duty and length
+    uint8_t duty;            // duty cycle (0-3)
+    uint8_t length_counter;  // length counter (0-63)
+    bool length_enabled;     // length enabled (true/false)
+
+    // envelope
+    uint8_t envelope_volume;        // envelope volume (0-15)
+    uint8_t enevelope_init_volume;  // initial envelope volume (0-15)
+    uint8_t envelope_period;        // envelope period (0-7)
+    bool
+        envelope_direction;  //  direction (true -> increase, false -> decrease)
+    int envelope_timer;      // envelope timer (in CPU cycles)
+
+    // frequency
+    uint16_t frequency;   // frequency (0-2047)
+    int frequency_timer;  // frequency timer (in CPU cycles)
+
+    // control and output
+    bool enabled;          // channel enabled (true/false)
+    bool dac_enabled;      // DAC enabled (true/false)
+    uint8_t output_level;  // output level (0-3)
+    int duty_position;     // current duty position (0-7)
+} ch2_t;
+
+/* channel 3 type */
+typedef struct {
+    uint8_t length_counter;  // length counter (0-256)
+    bool length_enabled;     // length enabled (true/false)
+    uint8_t output_level;    // output level (0-3)
+
+    uint16_t frequency;   // frequency (0-2047)
+    int frequency_timer;  // frequency timer (in CPU cycles)
+
+    bool enabled;           // channel enabled (true/false)
+    bool dac_enabled;       // DAC enabled (true/false)
+    uint8_t wave_position;  // current wave position (0-31)
+    uint8_t wave_ram[16];   // wave RAM (32 4-bit samples, 16 bytes)
+} ch3_t;
+
+/* channel 4 type */
+typedef struct {
+    uint8_t length_counter;  // length counter (0-64)
+    bool length_enabled;     // length enabled (true/false)
+
+    uint8_t envelope_volume;        // envelope volume (0-15)
+    uint8_t enevelope_init_volume;  // initial envelope volume (0-15)
+    uint8_t envelope_period;        // envelope period (0-7)
+    bool
+        envelope_direction;  //  direction (true -> increase, false -> decrease)
+    int envelope_timer;      // envelope timer (in CPU cycles)
+
+    uint8_t clock_shift;    // clock shift (0-7)
+    uint8_t clock_divider;  // clock divider (0-15)
+    bool width_mode;  // width mode (true -> 15-bit lsfr, false -> 7-bit lsfr)
+    uint16_t lfsr;    // linear feedback shift register
+    int frequency_timer;  // frequency timer (in CPU cycles)
+
+    bool enabled;          // channel enabled (true/false)
+    bool dac_enabled;      // DAC enabled (true/false)
+    uint8_t output_level;  // output level (0-3)
+} ch4_t;
+
+typedef struct APU {
+    struct CPU *cpu;
+    struct MMU *mmu;
+
+    ch1_t ch1;  // channel 1 (square wave with sweep)
+    ch2_t ch2;  // channel 2 (square wave without sweep)
+    ch3_t ch3;  // channel 3 (wave channel)
+    ch4_t ch4;  // channel 4 (noise channel)
+
+    // frame sequencer
+    int frame_sequencer_counter;   // frame sequencer counter
+    uint8_t frame_sequencer_step;  // current step in the frame sequencer (0-7)
+
+    // master control
+    bool sound_enabled;
+    uint8_t master_volume_left;
+    uint8_t master_volume_right;
+    uint8_t channel_panning;  // (NR51)
+
+    // audio output buffer
+    float *audio_buffer;
+    int buffer_position;  // current position in the audio buffer
+    int buffer_read_position;
+    int buffer_size;  // size of the audio buffer
+    double sample_counter;
+
+    float hp_alpha;              // filter coefficient
+    float hp_last_input_left;    // previous input sample (left)
+    float hp_last_input_right;   // previous input sample (right)
+    float hp_last_output_left;   // previous output sample (left)
+    float hp_last_output_right;  // previous output sample (right)
+
+    float lp_left;   // low-pass filter state (left)
+    float lp_right;  // low-pass filter state (right)
+
+    // channel fade states
+    float ch1_fade;   // 0.0 to 1.0
+    float ch2_fade;   // 0.0 to 1.0
+    float ch3_fade;   // 0.0 to 1.0
+    float ch4_fade;   // 0.0 to 1.0
+    float fade_rate;  // how fast channels fade in/out
+
+    // master volume fade
+    float master_fade;       // 0.0 to 1.0
+    float master_fade_rate;  // how fast master fades
+    bool sound_enabling;     // currently fading in
+    bool sound_disabling;    // currently fading out
+
+    // Buffer underrun handling
+    float last_output_left;   // for smooth underrun recovery
+    float last_output_right;  // for smooth underrun recovery
+
+    uint64_t cycles;
+    double cycles_per_sample;  // number of CPU cycles per audio sample
+
+} APU;
+
+void apu_init(APU *apu, struct CPU *cpu, struct MMU *mmu);
+void apu_reset(APU *apu);
+void apu_step(APU *apu, int cycles);
+
+/* mmu write/read handlers */
+void apu_write(APU *apu, uint16_t addr, uint8_t value);
+uint8_t apu_read(APU *apu, uint16_t addr);
+
+/* audio output */
+void apu_get_samples(APU *apu, float *buffer, int num_samples);
+
+#endif

--- a/include/apu.h
+++ b/include/apu.h
@@ -200,6 +200,12 @@ typedef struct APU {
     float last_output_left;   // for smooth underrun recovery
     float last_output_right;  // for smooth underrun recovery
 
+    // Channel state interpolation to reduce popping
+    float ch1_last_output;    // previous sample for smoothing
+    float ch2_last_output;    // previous sample for smoothing
+    float ch3_last_output;    // previous sample for smoothing
+    float ch4_last_output;    // previous sample for smoothing
+
     uint64_t cycles;
     double cycles_per_sample;  // number of CPU cycles per audio sample
 

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "apu.h"
 #include "mmu.h"
 #include "ppu.h"
 #include "timer.h"
@@ -16,11 +17,13 @@ extern FILE *cpu_log;
 struct MMU;
 struct Timer;
 struct PPU;
+struct APU;
 
 typedef struct CPU {
     struct MMU *mmu;     /* pointer to the MMU */
     struct Timer *timer; /* pointer to the timer */
     struct PPU *ppu;     /* pointer to the PPU */
+    struct APU *apu;     /* pointer to the APU */
 
     // a: accumulator; f: flags
     union {
@@ -95,7 +98,8 @@ typedef struct CPU {
 
 void tick(CPU *cpu, int cycles);
 
-void cpu_init(CPU *cpu, struct MMU *mmu, struct Timer *timer, struct PPU *ppu);
+void cpu_init(CPU *cpu, struct MMU *mmu, struct Timer *timer, struct PPU *ppu,
+              struct APU *apu);
 void cpu_step(CPU *cpu);
 
 #endif

--- a/include/mmu.h
+++ b/include/mmu.h
@@ -13,6 +13,27 @@
 #define TMA 0xFF06   // TMA register
 #define TAC 0xFF07   // TAC register
 #define IF 0xFF0F    // IF register
+#define NR10 0xFF10  // NR10 register (CH1)
+#define NR11 0xFF11  // NR11 register (CH1)
+#define NR12 0xFF12  // NR12 register (CH1)
+#define NR13 0xFF13  // NR13 register (CH1)
+#define NR14 0xFF14  // NR14 register (CH1)
+#define NR21 0xFF16  // NR21 register (CH2)
+#define NR22 0xFF17  // NR22 register (CH2)
+#define NR23 0xFF18  // NR23 register (CH2)
+#define NR24 0xFF19  // NR24 register (CH2)
+#define NR30 0xFF1A  // NR30 register (CH3)
+#define NR31 0xFF1B  // NR31 register (CH3)
+#define NR32 0xFF1C  // NR32 register (CH3)
+#define NR33 0xFF1D  // NR33 register (CH3)
+#define NR34 0xFF1E  // NR34 register (CH3)
+#define NR41 0xFF20  // NR41 register (CH4)
+#define NR42 0xFF21  // NR42 register (CH4)
+#define NR43 0xFF22  // NR43 register (CH4)
+#define NR44 0xFF23  // NR44 register (CH4)
+#define NR50 0xFF24  // NR50 (sound volume control)
+#define NR51 0xFF25  // NR51 (sound panning)
+#define NR52 0xFF26  // NR52 (sound on/off)
 #define LCDC 0xFF40  // LCD control
 #define STAT 0xFF41  // LCD status
 #define SCY 0xFF42   // scroll Y
@@ -28,12 +49,14 @@ struct CPU;
 struct Timer;
 struct PPU;
 struct Joypad;
+struct APU;
 
 typedef struct MMU {
     struct CPU *cpu;        // pointer to the CPU
     struct Timer *timer;    // pointer to the timer
     struct PPU *ppu;        // pointer to the PPU
     struct Joypad *joypad;  // pointer to the joypad
+    struct APU *apu;        // pointer to the APU
 
     /* cartridge data */
     uint8_t *cartridge_rom;       // dynamically allocated ROM data
@@ -76,7 +99,7 @@ typedef struct MMU {
 
 // initialize and reset the MMU
 void mmu_init(MMU *mmu, struct CPU *cpu, struct Timer *timer, struct PPU *ppu,
-              struct Joypad *joypad);
+              struct Joypad *joypad, struct APU *apu);
 void mmu_reset(MMU *mmu);
 
 // free the memory allocated for the banking controller

--- a/lib/apu.c
+++ b/lib/apu.c
@@ -1,0 +1,720 @@
+#include "apu.h"
+
+#include <math.h>
+#include <stdint.h>
+
+#include "cpu.h"
+#include "mmu.h"
+
+/* helper functions */
+static const uint8_t duty_table[4][8] = {
+    {0, 0, 0, 0, 0, 0, 0, 1},  // 12.5%
+    {1, 0, 0, 0, 0, 0, 0, 1},  // 25%
+    {1, 0, 0, 0, 0, 1, 1, 1},  // 50%
+    {0, 1, 1, 1, 1, 1, 1, 0},  // 75%
+};
+
+static uint8_t get_ch1_output(APU *apu) {
+    if (!apu->ch1.enabled || !apu->ch1.dac_enabled) {
+        return 0;
+    }
+    return duty_table[apu->ch1.duty][apu->ch1.duty_position] * apu->ch1.envelope_volume;
+}
+
+static uint8_t get_ch2_output(APU *apu) {
+    if (!apu->ch2.enabled || !apu->ch2.dac_enabled) {
+        return 0;
+    }
+    return duty_table[apu->ch2.duty][apu->ch2.duty_position] * apu->ch2.envelope_volume;
+}
+
+static uint8_t get_ch3_output(APU *apu) {
+    if (!apu->ch3.enabled || !apu->ch3.dac_enabled) {
+        return 0;
+    }
+
+    uint8_t sample = apu->ch3.wave_ram[apu->ch3.wave_position >> 1];
+
+    if (apu->ch3.wave_position & 1) {
+        sample &= 0x0F;  // get low nibble
+    } else {
+        sample >>= 4;  // get high nibble
+    }
+
+    switch (apu->ch3.output_level) {
+        case 0:  return 0;            // mute
+        case 1:  return sample;       // 100%
+        case 2:  return sample >> 1;  // 50%
+        case 3:  return sample >> 2;  // 25%
+        default: return 0;
+    }
+}
+
+static uint8_t get_ch4_output(APU *apu) {
+    if (!apu->ch4.enabled || !apu->ch4.dac_enabled) {
+        return 0;
+    }
+
+    // LFSR output is inverted
+    uint8_t lfsr_output = (~apu->ch4.lfsr) & 0x01;  // get the least significant bit
+    return lfsr_output * apu->ch4.envelope_volume;
+}
+
+static void clock_length_counters(APU *apu) {
+    if (apu->ch1.length_enabled && apu->ch1.length_counter > 0) {
+        apu->ch1.length_counter--;
+        if (apu->ch1.length_counter == 0) {
+            apu->ch1.enabled = false;  // disable channel if length counter reaches 0
+        }
+    }
+
+    if (apu->ch2.length_enabled && apu->ch2.length_counter > 0) {
+        apu->ch2.length_counter--;
+        if (apu->ch2.length_counter == 0) {
+            apu->ch2.enabled = false;  // disable channel if length counter reaches 0
+        }
+    }
+
+    if (apu->ch3.length_enabled && apu->ch3.length_counter > 0) {
+        apu->ch3.length_counter--;
+        if (apu->ch3.length_counter == 0) {
+            apu->ch3.enabled = false;  // disable channel if length counter reaches 0
+        }
+    }
+
+    if (apu->ch4.length_enabled && apu->ch4.length_counter > 0) {
+        apu->ch4.length_counter--;
+        if (apu->ch4.length_counter == 0) {
+            apu->ch4.enabled = false;  // disable channel if length counter reaches 0
+        }
+    }
+}
+
+static void clock_envelope(APU *apu) {
+    if (apu->ch1.envelope_period != 0) {
+        if (apu->ch1.envelope_timer > 0) {
+            apu->ch1.envelope_timer--;
+        }
+        if (apu->ch1.envelope_timer == 0) {
+            apu->ch1.envelope_timer = apu->ch1.envelope_period;
+            if (apu->ch1.envelope_direction && apu->ch1.envelope_volume < 15) {
+                apu->ch1.envelope_volume++;
+            } else if (!apu->ch1.envelope_direction && apu->ch1.envelope_volume > 0) {
+                apu->ch1.envelope_volume--;
+            }
+        }
+    }
+
+    if (apu->ch2.envelope_period != 0) {
+        if (apu->ch2.envelope_timer > 0) {
+            apu->ch2.envelope_timer--;
+        }
+        if (apu->ch2.envelope_timer == 0) {
+            apu->ch2.envelope_timer = apu->ch2.envelope_period;
+            if (apu->ch2.envelope_direction && apu->ch2.envelope_volume < 15) {
+                apu->ch2.envelope_volume++;
+            } else if (!apu->ch2.envelope_direction && apu->ch2.envelope_volume > 0) {
+                apu->ch2.envelope_volume--;
+            }
+        }
+    }
+
+    if (apu->ch4.envelope_period != 0) {
+        if (apu->ch4.envelope_timer > 0) {
+            apu->ch4.envelope_timer--;
+        }
+        if (apu->ch4.envelope_timer == 0) {
+            apu->ch4.envelope_timer = apu->ch4.envelope_period;
+            if (apu->ch4.envelope_direction && apu->ch4.envelope_volume < 15) {
+                apu->ch4.envelope_volume++;
+            } else if (!apu->ch4.envelope_direction && apu->ch4.envelope_volume > 0) {
+                apu->ch4.envelope_volume--;
+            }
+        }
+    }
+}
+
+static int calculate_sweep_frequency(APU *apu) {
+    int new_frequency = apu->ch1.sweep_shadow_frequency >> apu->ch1.sweep_shift;
+
+    if (apu->ch1.sweep_negate) {
+        new_frequency = apu->ch1.sweep_shadow_frequency - new_frequency;
+    } else {
+        new_frequency = apu->ch1.sweep_shadow_frequency + new_frequency;
+    }
+
+    if (new_frequency > 2047) {
+        apu->ch1.enabled = false;  // disable channel if frequency exceeds limit
+    }
+
+    return new_frequency;
+}
+
+static void clock_sweep(APU *apu) {
+    if (apu->ch1.sweep_timer > 0) {
+        apu->ch1.sweep_timer--;
+    }
+
+    if (apu->ch1.sweep_timer == 0) {
+        apu->ch1.sweep_timer = apu->ch1.sweep_period ? apu->ch1.sweep_period : 8;
+
+        if (apu->ch1.sweep_enabled && apu->ch1.sweep_period > 0) {
+            int new_frequency = calculate_sweep_frequency(apu);
+            if (new_frequency < 2048 && apu->ch1.sweep_shift > 0) {
+                apu->ch1.frequency              = new_frequency;
+                apu->ch1.sweep_shadow_frequency = new_frequency;
+                calculate_sweep_frequency(apu);
+            }
+        }
+    }
+}
+
+static int get_noise_period(APU *apu) {
+    static const int divisors[8] = {4, 8, 16, 24, 32, 40, 48, 56};
+    int divider_index            = apu->ch4.clock_divider & 0x07;  // mask to get the last 3 bits
+    return divisors[divider_index] << apu->ch4.clock_shift;
+}
+
+static void trigger_ch1(APU *apu) {
+    apu->ch1.enabled = apu->ch1.dac_enabled = true;
+
+    if (apu->ch1.length_counter == 0) {
+        apu->ch1.length_counter = 64;
+    }
+
+    apu->ch1.frequency_timer        = (2048 - apu->ch1.frequency) * 4;
+    apu->ch1.envelope_volume        = apu->ch1.enevelope_init_volume;
+    apu->ch1.envelope_timer         = apu->ch1.envelope_period;
+
+    apu->ch1.sweep_shadow_frequency = apu->ch1.frequency;
+    apu->ch1.sweep_timer            = apu->ch1.sweep_period ? apu->ch1.sweep_period : 8;
+    apu->ch1.sweep_enabled          = apu->ch1.sweep_period > 0 || apu->ch1.sweep_shift > 0;
+
+    if (apu->ch1.sweep_shift > 0) {
+        calculate_sweep_frequency(apu);
+    }
+}
+
+static void trigger_ch2(APU *apu) {
+    apu->ch2.enabled = apu->ch2.dac_enabled = true;
+
+    if (apu->ch2.length_counter == 0) {
+        apu->ch2.length_counter = 64;
+    }
+
+    apu->ch2.frequency_timer = (2048 - apu->ch2.frequency) * 4;
+    apu->ch2.envelope_volume = apu->ch2.enevelope_init_volume;
+    apu->ch2.envelope_timer  = apu->ch2.envelope_period;
+}
+
+static void trigger_ch3(APU *apu) {
+    apu->ch3.enabled = apu->ch3.dac_enabled = true;
+
+    if (apu->ch3.length_counter == 0) {
+        apu->ch3.length_counter = 255;
+    }
+
+    apu->ch3.frequency_timer = (2048 - apu->ch3.frequency) * 2;  // frequency timer for wave channel
+    apu->ch3.wave_position   = 0;                                // reset wave position
+}
+
+static void trigger_ch4(APU *apu) {
+    apu->ch4.enabled = apu->ch4.dac_enabled = true;
+
+    if (apu->ch4.length_counter == 0) {
+        apu->ch4.length_counter = 64;
+    }
+
+    apu->ch4.frequency_timer = get_noise_period(apu);
+    apu->ch4.envelope_volume = apu->ch4.enevelope_init_volume;
+    apu->ch4.envelope_timer  = apu->ch4.envelope_period;
+    apu->ch4.lfsr            = 0x7FFF;  // reset LFSR to a known state
+}
+
+static void frame_sequencer_step(APU *apu) {
+    // clock length counters on steps 0, 2, 4, 6
+    // clock envelope on step 7
+    // clock sweep on steps 2 and 6
+
+    switch (apu->frame_sequencer_step) {
+        case 0:
+        case 4: clock_length_counters(apu); break;
+        case 2:
+        case 6:
+            clock_length_counters(apu);
+            clock_sweep(apu);
+            break;
+        case 7: clock_envelope(apu); break;
+    }
+
+    apu->frame_sequencer_step = (apu->frame_sequencer_step + 1) & 7;
+}
+
+static void update_channel_timers(APU *apu, int cycles) {
+    if (apu->ch1.enabled) {
+        int period = (2048 - apu->ch1.frequency) * 4;
+        int timer  = apu->ch1.frequency_timer - cycles;
+
+        if (timer <= 0) {
+            int ticks = 1 + (-timer) / period; /* how many steps we missed */
+            timer += ticks * period;           /* catch up in one go      */
+            apu->ch1.duty_position = (apu->ch1.duty_position + ticks) & 7;
+        }
+        apu->ch1.frequency_timer = timer;
+    }
+
+    if (apu->ch2.enabled) {
+        int period = (2048 - apu->ch2.frequency) * 4;
+        int timer  = apu->ch2.frequency_timer - cycles;
+
+        if (timer <= 0) {
+            int ticks = 1 + (-timer) / period;
+            timer += ticks * period;
+            apu->ch2.duty_position = (apu->ch2.duty_position + ticks) & 7;
+        }
+        apu->ch2.frequency_timer = timer;
+    }
+
+    if (apu->ch3.enabled) {
+        int period = (2048 - apu->ch3.frequency) * 2; /* wave is x1/2 */
+        int timer  = apu->ch3.frequency_timer - cycles;
+
+        if (timer <= 0) {
+            int ticks = 1 + (-timer) / period;
+            timer += ticks * period;
+            apu->ch3.wave_position = (apu->ch3.wave_position + ticks) & 31;
+        }
+        apu->ch3.frequency_timer = timer;
+    }
+
+    if (apu->ch4.enabled) {
+        int period = get_noise_period(apu); /* 4 … 895 CPU cycles */
+        int timer  = apu->ch4.frequency_timer - cycles;
+
+        if (timer <= 0) {
+            int steps = 1 + (-timer) / period;
+            timer += steps * period;
+
+            /* advance the 15-bit or 7-bit LFSR exactly <steps> times */
+            uint16_t lfsr = apu->ch4.lfsr;
+            for (int s = 0; s < steps; ++s) {
+                uint8_t bit = (lfsr ^ (lfsr >> 1)) & 1;
+                lfsr        = (lfsr >> 1) | (bit << 14); /* 15-bit variant */
+                if (!apu->ch4.width_mode)                /* 7-bit mode */
+                    lfsr = (lfsr & ~0x40) | (bit << 6);
+            }
+            apu->ch4.lfsr = lfsr;
+        }
+        apu->ch4.frequency_timer = timer;
+    }
+}
+
+static inline float to_signed(int raw) { return (float)raw - 7.5f; }
+
+static void update_channel_fades(APU *apu) {
+    // ch1
+    if (apu->ch1.enabled && apu->ch1.dac_enabled) {
+        apu->ch1_fade = fminf(1.0f, apu->ch1_fade + apu->fade_rate);
+    } else {
+        apu->ch1_fade = fmaxf(0.0f, apu->ch1_fade - apu->fade_rate);
+    }
+
+    // ch2
+    if (apu->ch2.enabled && apu->ch2.dac_enabled) {
+        apu->ch2_fade = fminf(1.0f, apu->ch2_fade + apu->fade_rate);
+    } else {
+        apu->ch2_fade = fmaxf(0.0f, apu->ch2_fade - apu->fade_rate);
+    }
+
+    // ch3
+    if (apu->ch3.enabled && apu->ch3.dac_enabled) {
+        apu->ch3_fade = fminf(1.0f, apu->ch3_fade + apu->fade_rate);
+    } else {
+        apu->ch3_fade = fmaxf(0.0f, apu->ch3_fade - apu->fade_rate);
+    }
+
+    // ch4
+    if (apu->ch4.enabled && apu->ch4.dac_enabled) {
+        apu->ch4_fade = fminf(1.0f, apu->ch4_fade + apu->fade_rate);
+    } else {
+        apu->ch4_fade = fmaxf(0.0f, apu->ch4_fade - apu->fade_rate);
+    }
+}
+
+static void generate_sample(APU *apu) {
+    update_channel_fades(apu);
+
+    float ch1  = to_signed(get_ch1_output(apu)) * apu->ch1_fade;
+    float ch2  = to_signed(get_ch2_output(apu)) * apu->ch2_fade;
+    float ch3  = to_signed(get_ch3_output(apu)) * apu->ch3_fade;
+    float ch4  = to_signed(get_ch4_output(apu)) * apu->ch4_fade;
+
+    float left = 0.0f, right = 0.0f;
+
+    // apply panning and volume
+    if (apu->channel_panning & 0x10)
+        left += ch1;
+    if (apu->channel_panning & 0x01)
+        right += ch1;
+
+    if (apu->channel_panning & 0x20)
+        left += ch2;
+    if (apu->channel_panning & 0x02)
+        right += ch2;
+
+    if (apu->channel_panning & 0x40)
+        left += ch3;
+    if (apu->channel_panning & 0x04)
+        right += ch3;
+
+    if (apu->channel_panning & 0x80)
+        left += ch4;
+    if (apu->channel_panning & 0x08)
+        right += ch4;
+
+    // apply master volume
+    left *= (apu->master_volume_left + 1) / 8.0f;
+    right *= (apu->master_volume_right + 1) / 8.0f;
+
+    left *= apu->master_fade;
+    right *= apu->master_fade;
+
+    if (apu->sound_disabling) {
+        apu->master_fade -= apu->master_fade_rate;
+        if (apu->master_fade <= 0.0f) {
+            apu->master_fade     = 0.0f;
+            apu->sound_disabling = false;
+            apu->sound_enabled   = false;
+        }
+    } else if (apu->sound_enabling) {
+        apu->master_fade += apu->master_fade_rate;
+        if (apu->master_fade >= 1.0f) {
+            apu->master_fade    = 1.0f;
+            apu->sound_enabling = false;
+        }
+    }
+
+    // normalize between -1.0f and 1.0f
+    left /= 30.0f;  // max possible value is 30.0f (4 channels * 7.5f)
+    right /= 30.0f;
+
+    const float lp_alpha = 0.25f;  // Adjust this: lower = more smoothing
+    left                 = apu->lp_left + lp_alpha * (left - apu->lp_left);
+    right                = apu->lp_right + lp_alpha * (right - apu->lp_right);
+    apu->lp_left         = left;
+    apu->lp_right        = right;
+
+    // clamp values to prevent clipping
+    left                 = fmaxf(-1.0f, fminf(1.0f, left));
+    right                = fmaxf(-1.0f, fminf(1.0f, right));
+
+    // high-pass filter to remove DC offset
+    float out_l = apu->hp_alpha * (apu->hp_last_output_left + left - apu->hp_last_input_left);
+    float out_r = apu->hp_alpha * (apu->hp_last_output_right + right - apu->hp_last_input_right);
+
+    apu->hp_last_input_left                   = left;
+    apu->hp_last_input_right                  = right;
+    apu->hp_last_output_left                  = out_l;
+    apu->hp_last_output_right                 = out_r;
+
+    // store in buffer
+    apu->audio_buffer[apu->buffer_position++] = out_l;
+    apu->audio_buffer[apu->buffer_position++] = out_r;
+
+    // wrap buffer position if necessary
+    if (apu->buffer_position >= apu->buffer_size * 2) {
+        apu->buffer_position = 0;
+    }
+}
+
+static void power_off(APU *apu) {
+    if (apu->sound_enabled) {
+        apu->sound_disabling = true;
+        return;  // don't reset channels yet
+    }
+
+    // disable all channels
+    apu->ch1                 = (ch1_t){0};  // reset channel 1
+    apu->ch2                 = (ch2_t){0};  // reset channel 2
+    apu->ch3                 = (ch3_t){0};  // reset channel 3
+    apu->ch4                 = (ch4_t){0};  // reset channel 4
+
+    // reset master control
+    apu->sound_enabled       = false;
+    apu->master_volume_left  = 0;
+    apu->master_volume_right = 0;
+    apu->channel_panning     = 0;
+}
+
+static void init_highpass_filter(APU *apu, float cutoff_hz) {
+    float sample_rate = 48000.0f;
+    float rc          = 1.0f / (2.0f * M_PI * cutoff_hz);
+    float dt          = 1.0f / sample_rate;
+    apu->hp_alpha     = rc / (rc + dt);
+}
+
+/* APU API functions */
+void apu_init(APU *apu, struct CPU *cpu, struct MMU *mmu) {
+    apu->cpu          = cpu;
+    apu->mmu          = mmu;
+
+    apu->buffer_size  = 2048;
+    apu->audio_buffer = malloc(apu->buffer_size * sizeof(float) * 2);  // * 2 for stereo
+    if (!apu->audio_buffer) {
+        fprintf(stderr, "Failed to allocate audio buffer\n");
+        exit(EXIT_FAILURE);
+    }
+
+    apu->fade_rate        = 0.0002f;
+    apu->master_fade_rate = 0.0001f;
+
+    // initialize high-pass filter with 30Hz cutoff
+    init_highpass_filter(apu, 20.0f);
+
+    apu_reset(apu);
+}
+
+void apu_reset(APU *apu) {
+    // reset channels
+    memset(&apu->ch1, 0, sizeof(ch1_t));
+    memset(&apu->ch2, 0, sizeof(ch2_t));
+    memset(&apu->ch3, 0, sizeof(ch3_t));
+    memset(&apu->ch4, 0, sizeof(ch4_t));
+
+    apu->ch4.lfsr                = 0x7FFF;  // initialize noise channel LFSR to a known state
+
+    // reset frame sequencer
+    apu->frame_sequencer_counter = 0;
+    apu->frame_sequencer_step    = 0;
+
+    // reset master control
+    apu->sound_enabled           = false;
+    apu->master_volume_left      = 0;
+    apu->master_volume_right     = 0;
+    apu->channel_panning         = 0;
+
+    // reset audio buffer
+    apu->buffer_position         = 0;
+    apu->buffer_read_position    = 0;
+
+    // reset high-pass filter state
+    apu->hp_last_input_left      = 0.0f;
+    apu->hp_last_input_right     = 0.0f;
+    apu->hp_last_output_left     = 0.0f;
+    apu->hp_last_output_right    = 0.0f;
+
+    // reset low-pass filter state
+    apu->lp_left                 = 0.0f;
+    apu->lp_right                = 0.0f;
+
+    // reset fade states
+    apu->ch1_fade                = 0.0f;
+    apu->ch2_fade                = 0.0f;
+    apu->ch3_fade                = 0.0f;
+    apu->ch4_fade                = 0.0f;
+    apu->master_fade             = 0.0f;
+    apu->sound_enabling          = false;
+    apu->sound_disabling         = false;
+
+    // for buffer underrun handling
+    apu->last_output_left        = 0.0f;
+    apu->last_output_right       = 0.0f;
+
+    apu->cycles                  = 0;
+    apu->cycles_per_sample       = 4194304.0 / 48000.0;
+    apu->sample_counter          = 0.0;
+
+    for (int i = 0; i < 16; i++) {
+        apu->ch3.wave_ram[i] = (i << 4) | i;  // initialize wave RAM with a simple pattern
+    }
+}
+
+void apu_step(APU *apu, int cycles) {
+    if (!apu->sound_enabled && !apu->sound_disabling) {
+        return;
+    }
+
+    apu->cycles += cycles;
+
+    apu->frame_sequencer_counter += cycles;
+    if (apu->frame_sequencer_counter >= 8192) {
+        apu->frame_sequencer_counter -= 8192;
+        frame_sequencer_step(apu);
+    }
+
+    update_channel_timers(apu, cycles);
+
+    // generate audio samples
+    apu->sample_counter += (double)cycles;
+    while (apu->sample_counter >= apu->cycles_per_sample) {
+        apu->sample_counter -= apu->cycles_per_sample;
+        generate_sample(apu);
+    }
+}
+
+void apu_get_samples(APU *apu, float *buffer, int num_samples) {
+    for (int i = 0; i < num_samples * 2; i += 2) {
+        int read_pos  = apu->buffer_read_position;
+        int write_pos = apu->buffer_position;
+
+        int available = (write_pos - read_pos + apu->buffer_size * 2) % (apu->buffer_size * 2);
+
+        if (available >= 2) {
+            // copy samples from audio buffer
+            buffer[i]                 = apu->audio_buffer[read_pos];
+            buffer[i + 1]             = apu->audio_buffer[(read_pos + 1) % (apu->buffer_size * 2)];
+
+            apu->last_output_left     = buffer[i];
+            apu->last_output_right    = buffer[i + 1];
+            apu->buffer_read_position = (read_pos + 2) % (apu->buffer_size * 2);
+        } else {
+            // if buffer is empty, fade to silence
+            buffer[i]              = apu->last_output_left * 0.95f;
+            buffer[i + 1]          = apu->last_output_right * 0.95f;
+            apu->last_output_left  = buffer[i];
+            apu->last_output_right = buffer[i + 1];
+        }
+    }
+}
+
+void apu_cleanup(APU *apu) {
+    if (apu->audio_buffer) {
+        free(apu->audio_buffer);
+        apu->audio_buffer = NULL;
+    }
+}
+
+/* MMU handlers */
+void apu_write(APU *apu, uint16_t addr, uint8_t value) {
+    if (!apu->sound_enabled && addr != NR52)
+        return;
+
+    switch (addr) {
+        case NR10:
+            apu->ch1.sweep_period = (value >> 4) & 0x07;  // 0-7
+            apu->ch1.sweep_negate = (value >> 3) & 0x01;  // 0 or 1
+            apu->ch1.sweep_shift  = value & 0x07;         // 0-7
+            break;
+        case NR11:
+            apu->ch1.duty           = (value >> 6) & 0x03;  // 0-3
+            apu->ch1.length_counter = 64 - (value & 0x3F);  // 0-64
+            break;
+        case NR12:
+            apu->ch1.enevelope_init_volume = (value >> 4) & 0x0F;
+            apu->ch1.envelope_direction    = (value >> 3) & 0x01;
+            apu->ch1.envelope_period       = value & 0x07;
+            apu->ch1.dac_enabled           = (value & 0xF8) != 0;
+            if (!apu->ch1.dac_enabled) {
+                apu->ch1.enabled = false;  // disable channel if DAC is disabled
+            }
+            break;
+        case NR13: apu->ch1.frequency = (apu->ch1.frequency & 0x700) | value; break;
+        case NR14:
+            apu->ch1.frequency      = (apu->ch1.frequency & 0xFF) | ((value & 0x07) << 8);
+            apu->ch1.length_enabled = (value >> 6) & 0x01;
+            if (value & 0x80) {
+                trigger_ch1(apu);
+            }
+            break;
+
+        case NR21:
+            apu->ch2.duty           = (value >> 6) & 0x03;  // 0-3
+            apu->ch2.length_counter = 64 - (value & 0x3F);  // 0-64
+            break;
+        case NR22:
+            apu->ch2.enevelope_init_volume = (value >> 4) & 0x0F;
+            apu->ch2.envelope_direction    = (value >> 3) & 0x01;
+            apu->ch2.envelope_period       = value & 0x07;
+            apu->ch2.dac_enabled           = (value & 0xF8) != 0;
+            if (!apu->ch2.dac_enabled) {
+                apu->ch2.enabled = false;  // disable channel if DAC is disabled
+            }
+            break;
+        case NR23: apu->ch2.frequency = (apu->ch2.frequency & 0x700) | value; break;
+        case NR24:
+            apu->ch2.frequency      = (apu->ch2.frequency & 0xFF) | ((value & 0x07) << 8);
+            apu->ch2.length_enabled = (value >> 6) & 0x01;
+            if (value & 0x80) {
+                trigger_ch2(apu);
+            }
+            break;
+
+        case NR30:
+            apu->ch3.dac_enabled = (value >> 7) & 0x01;  // enable/disable DAC
+            if (!apu->ch3.dac_enabled) {
+                apu->ch3.enabled = false;  // disable channel if DAC is disabled
+            }
+            break;
+        case NR31: apu->ch3.length_counter = 256 - value; break;
+        case NR32: apu->ch3.output_level = (value >> 5) & 0x03; break;
+        case NR33: apu->ch3.frequency = (apu->ch3.frequency & 0x700) | value; break;
+        case NR34:
+            apu->ch3.frequency      = (apu->ch3.frequency & 0xFF) | ((value & 0x07) << 8);
+            apu->ch3.length_enabled = (value >> 6) & 0x01;
+            if (value & 0x80) {
+                trigger_ch3(apu);
+            }
+            break;
+
+        case NR41:
+            apu->ch4.length_counter = 64 - (value & 0x3F);  // 0-64
+            break;
+        case NR42:
+            apu->ch4.enevelope_init_volume = (value >> 4) & 0x0F;
+            apu->ch4.envelope_direction    = (value >> 3) & 0x01;
+            apu->ch4.envelope_period       = value & 0x07;
+            apu->ch4.dac_enabled           = (value & 0xF8) != 0;
+            if (!apu->ch4.dac_enabled) {
+                apu->ch4.enabled = false;  // disable channel if DAC is disabled
+            }
+            break;
+        case NR43:
+            apu->ch4.clock_shift   = (value >> 4) & 0x0F;  // 0-15
+            apu->ch4.width_mode    = (value >> 3) & 0x01;  // 0 or 1
+            apu->ch4.clock_divider = value & 0x07;         // 0-7
+            break;
+        case NR44:
+            apu->ch4.length_enabled = (value >> 6) & 0x01;  // length enabled
+            if (value & 0x80) {
+                trigger_ch4(apu);
+            }
+            break;
+
+        case NR50:
+            apu->master_volume_left  = (value >> 4) & 0x07;  // left volume (0-7)
+            apu->master_volume_right = value & 0x07;         // right volume (0-7)
+            break;
+        case NR51:
+            apu->channel_panning = value;  // channel panning (0-255)
+            break;
+        case NR52:
+            if (!(value & 0x80)) {
+                power_off(apu);
+            } else if (!apu->sound_enabled && (value & 0x80)) {
+                apu->sound_enabled        = true;  // enable sound
+                apu->sound_enabling       = true;  // start fade-in
+                apu->frame_sequencer_step = 0;     // reset frame sequencer step
+            }
+            break;
+        default:  // wave ram
+            if (addr >= 0xFF30 && addr <= 0xFF3F) {
+                // write to wave RAM (0xFF30 - 0xFF3F)
+                apu->ch3.wave_ram[addr - 0xFF30] = value;
+            } else {
+                fprintf(stderr, "APU: Invalid write to address 0x%04X with value 0x%02X\n", addr,
+                        value);
+            }
+            break;
+    }
+}
+
+uint8_t apu_read(APU *apu, uint16_t addr) {
+    switch (addr) {
+        case NR52:
+            return (apu->sound_enabled ? 0x80 : 0x00) | (apu->ch1.enabled ? 0x01 : 0x00) |
+                   (apu->ch2.enabled ? 0x02 : 0x00) | (apu->ch3.enabled ? 0x04 : 0x00) |
+                   (apu->ch4.enabled ? 0x08 : 0x00) | 0x70;  // bits 4-6 are always 1
+
+        default: return 0xFF;  // undefined behavior
+    }
+}

--- a/lib/apu.c
+++ b/lib/apu.c
@@ -207,7 +207,7 @@ static int get_noise_period(APU *apu) {
 }
 
 static void trigger_ch1(APU *apu) {
-    apu->ch1.enabled = apu->ch1.dac_enabled = true;
+    apu->ch1.enabled = apu->ch1.dac_enabled;
 
     if (apu->ch1.length_counter == 0) {
         apu->ch1.length_counter = 64;
@@ -227,7 +227,7 @@ static void trigger_ch1(APU *apu) {
 }
 
 static void trigger_ch2(APU *apu) {
-    apu->ch2.enabled = apu->ch2.dac_enabled = true;
+    apu->ch2.enabled = apu->ch2.dac_enabled;
 
     if (apu->ch2.length_counter == 0) {
         apu->ch2.length_counter = 64;
@@ -239,7 +239,7 @@ static void trigger_ch2(APU *apu) {
 }
 
 static void trigger_ch3(APU *apu) {
-    apu->ch3.enabled = apu->ch3.dac_enabled = true;
+    apu->ch3.enabled = apu->ch3.dac_enabled;
 
     if (apu->ch3.length_counter == 0) {
         apu->ch3.length_counter = 255;
@@ -250,7 +250,7 @@ static void trigger_ch3(APU *apu) {
 }
 
 static void trigger_ch4(APU *apu) {
-    apu->ch4.enabled = apu->ch4.dac_enabled = true;
+    apu->ch4.enabled = apu->ch4.dac_enabled;
 
     if (apu->ch4.length_counter == 0) {
         apu->ch4.length_counter = 64;
@@ -779,12 +779,62 @@ void apu_write(APU *apu, uint16_t addr, uint8_t value) {
 }
 
 uint8_t apu_read(APU *apu, uint16_t addr) {
+    /* wave RAM is always readable */
+    if (addr >= 0xFF30 && addr <= 0xFF3F) {
+        return apu->ch3.wave_ram[addr - 0xFF30];
+    }
+
     switch (addr) {
+        /* CH1 registers */
+        case NR10:
+            return ((apu->ch1.sweep_period << 4) |
+                    (apu->ch1.sweep_negate << 3) |
+                    apu->ch1.sweep_shift) | 0x80;
+        case NR11: return (apu->ch1.duty << 6) | 0x3F;
+        case NR12:
+            return (apu->ch1.enevelope_init_volume << 4) |
+                   (apu->ch1.envelope_direction << 3) |
+                   apu->ch1.envelope_period;
+        case NR13: return 0xFF;  // write-only
+        case NR14: return (apu->ch1.length_enabled ? 0x40 : 0x00) | 0xBF;
+
+        /* CH2 registers */
+        case NR21: return (apu->ch2.duty << 6) | 0x3F;
+        case NR22:
+            return (apu->ch2.enevelope_init_volume << 4) |
+                   (apu->ch2.envelope_direction << 3) |
+                   apu->ch2.envelope_period;
+        case NR23: return 0xFF;  // write-only
+        case NR24: return (apu->ch2.length_enabled ? 0x40 : 0x00) | 0xBF;
+
+        /* CH3 registers */
+        case NR30: return (apu->ch3.dac_enabled ? 0x80 : 0x00) | 0x7F;
+        case NR31: return 0xFF;  // write-only
+        case NR32: return (apu->ch3.output_level << 5) | 0x9F;
+        case NR33: return 0xFF;  // write-only
+        case NR34: return (apu->ch3.length_enabled ? 0x40 : 0x00) | 0xBF;
+
+        /* CH4 registers */
+        case NR41: return 0xFF;  // write-only
+        case NR42:
+            return (apu->ch4.enevelope_init_volume << 4) |
+                   (apu->ch4.envelope_direction << 3) |
+                   apu->ch4.envelope_period;
+        case NR43:
+            return (apu->ch4.clock_shift << 4) |
+                   (apu->ch4.width_mode << 3) |
+                   apu->ch4.clock_divider;
+        case NR44: return (apu->ch4.length_enabled ? 0x40 : 0x00) | 0xBF;
+
+        /* master control registers */
+        case NR50:
+            return (apu->master_volume_left << 4) | apu->master_volume_right;
+        case NR51: return apu->channel_panning;
         case NR52:
             return (apu->sound_enabled ? 0x80 : 0x00) | (apu->ch1.enabled ? 0x01 : 0x00) |
                    (apu->ch2.enabled ? 0x02 : 0x00) | (apu->ch3.enabled ? 0x04 : 0x00) |
-                   (apu->ch4.enabled ? 0x08 : 0x00) | 0x70;  // bits 4-6 are always 1
+                   (apu->ch4.enabled ? 0x08 : 0x00) | 0x70;  // bits 4-6 always 1
 
-        default: return 0xFF;  // undefined behavior
+        default: return 0xFF;  // unmapped APU address
     }
 }

--- a/lib/cpu.c
+++ b/lib/cpu.c
@@ -15,12 +15,14 @@ FILE *cpu_log = NULL;
 - sets all regular regs to zero
 - puts pc and sp at their designated place
 */
-void cpu_init(struct CPU *cpu, struct MMU *mmu, struct Timer *timer, struct PPU *ppu) {
+void cpu_init(struct CPU *cpu, struct MMU *mmu, struct Timer *timer, struct PPU *ppu,
+              struct APU *apu) {
     *cpu       = (CPU){0};
 
     cpu->mmu   = mmu;
     cpu->timer = timer;
     cpu->ppu   = ppu;
+    cpu->apu   = apu;
 
     /* debug register init */
     cpu->a     = 0x01;
@@ -56,6 +58,7 @@ void tick(CPU *cpu, int cycles) {
     cpu->cycles += cycles;
     timer_step(cpu->timer, cycles); /* update the timer */
     ppu_step(cpu->ppu, cycles);     /* update the PPU */
+    apu_step(cpu->apu, cycles);     /* update the APU */
 }
 
 /* function to process an interrupt

--- a/lib/mmu.c
+++ b/lib/mmu.c
@@ -115,7 +115,11 @@ uint8_t mmu_read(MMU *mmu, uint16_t addr) {
             case STAT:   return (mmu->io[0x41] & 0xF8) | (mmu->ppu->mode & 0x03); /* STAT register */
             case 0xFF4D: /* undocumented read */
             case 0xFF56: return 0xFF;
-            default:     return mmu->io[addr - 0xFF00]; /* read from other IO registers */
+            default:
+                if (addr >= 0xFF30 && addr <= 0xFF3F) {
+                    return apu_read(mmu->apu, addr);  /* wave RAM */
+                }
+                return mmu->io[addr - 0xFF00]; /* read from other IO registers */
         }
     } else if (addr < IE) {
         return mmu->hram[addr - 0xFF80]; /* read from HRAM */
@@ -194,7 +198,13 @@ void mmu_write(MMU *mmu, uint16_t addr, uint8_t value) {
                     mmu->boot_rom_enabled = false;
                     printf("Boot ROM disabled\n");
                 }
-            default: mmu->io[addr - 0xFF00] = value; break; /* write to other IO registers */
+            default:
+                if (addr >= 0xFF30 && addr <= 0xFF3F) {
+                    apu_write(mmu->apu, addr, value);  /* wave RAM */
+                } else {
+                    mmu->io[addr - 0xFF00] = value; /* write to other IO registers */
+                }
+                break;
         }
         return;
     } else if (addr < IE) {

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
     AudioStream stream = LoadAudioStream(48000, 32, 2);
     SetAudioStreamCallback(stream, AudioInputCallback);
     PlayAudioStream(stream);
-    SetAudioStreamVolume(stream, 0.2f);
+    SetAudioStreamVolume(stream, 0.05f);  // restore some volume after improvements
 
     Image image       = GenImageColor(WIDTH_PX, HEIGHT_PX, BLANK);
     Texture2D texture = LoadTextureFromImage(image);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large new subsystem touches the memory bus (`NRxx` IO handling) and the core tick loop, so timing/regression risk is moderate even though it’s not security-sensitive.
> 
> **Overview**
> Implements a new `APU` module (4 channels + frame sequencer) that generates 48kHz stereo samples with basic mixing/panning/volume and pop-reduction (fades, light filtering, soft clipping).
> 
> Integrates APU into the emulator core by threading an `APU*` through `cpu_init`/`mmu_init`, ticking audio in `tick()`, and routing `NR10`–`NR52` + wave RAM (`0xFF30`–`0xFF3F`) reads/writes through `apu_read`/`apu_write`.
> 
> Adds raylib audio stream setup in `main.c` with a callback that pulls samples from `apu_get_samples`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b1f1894d2c03cc7602a5d86589e6490103fde8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->